### PR TITLE
fix(ci): add zizmor pedantic persona, suppress noisy findings, fix cache key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: chainguard-dev/actions/setup-mirror@4a81273c8653122cf4e48cc248f9073b660c5e6d # v1.6.18
 
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.25'
@@ -63,9 +64,9 @@ jobs:
             ~/go/pkg/mod
             ~/.cache/go-build
             ${{ env.KOCACHE }}
-          key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-go-${{ matrix.go-version }}-
+            ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-
 
       - uses: step-security/setup-ko@3b4d97844e4277c74a9d77ac00052d8ce96580d3 # v0.9.0
         with:

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/dependabot.yml'
+      - '.github/zizmor.yml'
 
 permissions: {}
 
@@ -42,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,18 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Zizmor configuration for exitdir.
+# CI runs zizmor with --pedantic; rules with no security value are disabled
+# to keep CI signal-to-noise high. See PSEC-923 for rationale.
+
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  # Pedantic-only; no security impact — cosmetic/style findings
+  anonymous-definition:
+    disable: true
+  # Pedantic-only; low security value but extremely noisy
+  # Address concurrency limits as a separate, dedicated effort if desired
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

## Summary

This two-patch series adds the `persona: pedantic` configuration to the
zizmor CI workflow, suppresses noisy pedantic-only rules with no direct
security value, and fixes an actionlint finding in `integration.yml`.

## Patches

### 0001 — fix(ci): add pedantic persona and suppress noisy zizmor rules

Adds `.github/zizmor.yml` with the following configuration:

- `dependabot-cooldown: config: days: 3` — sets the expected minimum cooldown
  (2 findings: gomod + github-actions ecosystems)
- `anonymous-definition: disable: true` — pedantic-only, purely cosmetic
  (1 finding suppressed)
- `concurrency-limits: disable: true` — pedantic-only, low security value
  (5 findings suppressed)

Updates `.github/dependabot.yml` to add `cooldown: default-days: 3` to both
the gomod and github-actions update blocks, keeping it consistent with the
`days: 3` configured in zizmor.yml.

Updates `.github/workflows/zizmor.yaml` to:
- Pass `--pedantic` to zizmor-action
- Extend the `paths:` trigger to include `.github/dependabot.yml` and
  `.github/zizmor.yml`

## Findings addressed

| Rule | Count | Disposition |
|------|-------|-------------|
| `concurrency-limits` | 5 | Disabled in zizmor.yml (low security value) |
| `dependabot-cooldown` | 2 | cooldown: default-days: 3 added to dependabot.yml |
| `anonymous-definition` | 1 | Disabled in zizmor.yml (no security impact) |
| actionlint `go-version` | 2 | Fixed in patch 0002 — use steps.setup-go.outputs.go-version in cache key |

### 0002 — fix(ci): use setup-go output for cache key instead of undefined matrix var

The cache key in `integration.yml` referenced `${{ matrix.go-version }}` but
the matrix only defines `k8s-version`. Adds `id: setup-go` to the setup-go
step and replaces both occurrences with `${{ steps.setup-go.outputs.go-version }}`
so the cache key reflects the actual installed Go version.

## Testing

After merging, open a PR that modifies `.github/dependabot.yml` or
`.github/zizmor.yml` to verify the paths trigger fires. The zizmor check
should pass with zero findings.

Refs: PSEC-923